### PR TITLE
Feature/no ref/customize admin panel

### DIFF
--- a/calendarapi/admin/__init__.py
+++ b/calendarapi/admin/__init__.py
@@ -7,7 +7,7 @@ from calendarapi.admin.specialization import SpecializationAdminModelView
 from calendarapi.admin.user import UserAdminModelView
 from calendarapi.admin.city import CityAdminModelView
 from calendarapi.admin.lawyer import LawyerAdminModelView
-from calendarapi.admin.schedule import SheduleModelView
+from calendarapi.admin.schedule import ScheduleModelView
 
 __all__ = [
     "AdminModelView",
@@ -17,5 +17,5 @@ __all__ = [
     "CityAdminModelView",
     "SpecializationAdminModelView",
     "LawyerAdminModelView",
-    "SheduleModelView",
+    "ScheduleModelView",
 ]

--- a/calendarapi/admin/lawyer.py
+++ b/calendarapi/admin/lawyer.py
@@ -1,5 +1,6 @@
+from wtforms import StringField
 from wtforms.validators import DataRequired, ValidationError
-
+from wtforms.widgets import EmailInput
 from calendarapi.admin.common import AdminModelView
 from calendarapi.api.schemas import LawyerSchema
 
@@ -16,15 +17,24 @@ class LawyerAdminModelView(AdminModelView):
     column_labels = {
         "name": "Ім'я",
         "surname": "Прізвище",
-        "lawyer_mail": "Пошта",
+        # "lawyer_mail": "Пошта",
         "cities": "Місто",
         "specializations": "Спеціалізації",
+        "specializations.specialization_name": "Спец...",
+        "cities.city_name": "Місто",
     }
+    column_searchable_list = [
+        "name",
+        "surname",
+        # "lawyer_mail",
+        "cities.city_name",
+        "specializations.specialization_name",
+    ]
 
     column_list = [
         "name",
         "surname",
-        "lawyer_mail",
+        # "lawyer_mail",
         "cities",
         "specializations",
     ]
@@ -57,7 +67,11 @@ class LawyerAdminModelView(AdminModelView):
             "label": "Місто",
             "validators": [DataRequired()],
         },
-        "lawyer_mail": {
-            "validators": [EmailValidator()],
-        },
+        # "lawyer_mail": {
+        #     "validators": [EmailValidator()],
+        # },
+    }
+
+    form_extra_fields = {
+        "lawyer_mail": StringField(),
     }

--- a/calendarapi/admin/lawyer.py
+++ b/calendarapi/admin/lawyer.py
@@ -1,6 +1,5 @@
 from wtforms import StringField
 from wtforms.validators import DataRequired, ValidationError
-from wtforms.widgets import EmailInput
 from calendarapi.admin.common import AdminModelView
 from calendarapi.api.schemas import LawyerSchema
 
@@ -17,16 +16,21 @@ class LawyerAdminModelView(AdminModelView):
     column_labels = {
         "name": "Ім'я",
         "surname": "Прізвище",
-        # "lawyer_mail": "Пошта",
+        "lawyer_mail": "Пошта",
         "cities": "Місто",
         "specializations": "Спеціалізації",
         "specializations.specialization_name": "Спец...",
         "cities.city_name": "Місто",
     }
+    column_sortable_list = [
+        "name",
+        "surname",
+        "lawyer_mail",
+    ]
     column_searchable_list = [
         "name",
         "surname",
-        # "lawyer_mail",
+        "lawyer_mail",
         "cities.city_name",
         "specializations.specialization_name",
     ]
@@ -34,7 +38,7 @@ class LawyerAdminModelView(AdminModelView):
     column_list = [
         "name",
         "surname",
-        # "lawyer_mail",
+        "lawyer_mail",
         "cities",
         "specializations",
     ]
@@ -61,17 +65,13 @@ class LawyerAdminModelView(AdminModelView):
     form_args = {
         "specializations": {
             "label": "Спеціалізації",
-            "validators": [DataRequired()],
+            "validators": [DataRequired(message="Це поле обов'язкове.")],
         },
         "cities": {
             "label": "Місто",
-            "validators": [DataRequired()],
+            "validators": [DataRequired(message="Це поле обов'язкове.")],
         },
-        # "lawyer_mail": {
-        #     "validators": [EmailValidator()],
-        # },
-    }
-
-    form_extra_fields = {
-        "lawyer_mail": StringField(),
+        "lawyer_mail": {
+            "validators": [EmailValidator()],
+        },
     }

--- a/calendarapi/admin/schedule.py
+++ b/calendarapi/admin/schedule.py
@@ -6,13 +6,7 @@ from flask_admin import expose
 from wtforms import DateField, ValidationError
 from wtforms.validators import DataRequired
 
-# TODO imports
-from sqlalchemy import exists, or_, and_
-from flask_admin.contrib.sqla import ajax
-
-
 from calendarapi.admin.common import AdminModelView
-from calendarapi.models import layers_to_cities
 from calendarapi.models.city import City
 from calendarapi.models.lawyer import Lawyer
 from calendarapi.models.schedule import Schedule
@@ -26,20 +20,31 @@ class MaxItemsValidator:
 
     def __call__(self, form, field):
         if field.data and len(field.data) > self.max_items:
-            raise ValidationError(f"Можна обрати не більше {self.max_items}")
+            raise ValidationError(f"Можна обрати не більше {self.max_items}.")
 
 
 # example for validators without args
 def validate_time_format(form, field):
+    _validate_time_format(field.data)
+
+
+def _validate_time_format(time_list):
     try:
-        for time in field.data:
+        res = list()
+        for time in time_list:
             if time.count(":") > 1:
                 time_format = "%H:%M:%S"
-            else:
+            elif time.count(":") == 1:
                 time_format = "%H:%M"
-            datetime.strptime(time, time_format)
+            else:
+                time_format = "%H"
+            res.append(datetime.strptime(time, time_format).time())
+        return res
+
     except ValueError:
-        raise ValidationError("Invalid time format. Use 'HH:MM:SS' or 'HH:MM'.")
+        raise ValidationError(
+            "Невірний формат. Приймається час у вигляді 'HH:MM:SS' або 'HH:MM' або 'HH'."
+        )
 
 
 def validate_lawyers_for_date(form, field):
@@ -59,6 +64,7 @@ def validate_lawyers_for_date(form, field):
 
 
 class ScheduleModelView(AdminModelView):
+    can_set_page_size = True
     list_template = "admin/custom_list.html"
     current_city = "Оберіть місто"
 
@@ -74,7 +80,6 @@ class ScheduleModelView(AdminModelView):
             selected_city = "all"
         else:
             self.current_city = selected_city
-        # city = request.args.get('city')
         return redirect(f"?city={selected_city}")
 
     def get_query(self):
@@ -89,51 +94,31 @@ class ScheduleModelView(AdminModelView):
 
         if selected_city and selected_city != "all":
             self.selected_city = selected_city
-            self.test = db.session.query(Lawyer).filter(
-                Lawyer.cities.any(City.city_name == selected_city)
-            )
         else:
             self.selected_city = selected_city
-            self.test = db.session.query(Lawyer)
-
         return self.query
 
     @expose("/ajax/lookup/")
     def ajax_lookup(self):
-        # TODO
-        # query_test = self.test # model with select city filter
         select_city = self.selected_city  # select city from path args
-
         name = request.args.get("name")
         query = request.args.get("query")
-
         offset = request.args.get("offset", type=int)
         limit = request.args.get("limit", 10, type=int)
-
         loader = self._form_ajax_refs.get(name)
-        print("\n" * 15)
-        print(self.__dir__())
-        print(self.get_filters())
-
-        # ??
-        # self._apply_filters(query=)
-        # print('model', loader.model)
-        # print('get_list', loader.get_list)
-        # print('get_query', loader.get_query)
-        # print('filter', loader.filters)
-        # print(loader.get_query)
-        # self._filter_joins = ['JOIN TEST',]
         if not loader:
             abort(404)
+        sql_query = loader.get_list(query, offset, limit)
+        if select_city is None:
+            data = [loader.format(m) for m in loader.get_list(query, offset, limit)]
+            return Response(json.dumps(data), mimetype="application/json")
 
-        req = db.session.query(Lawyer).filter(
-            Lawyer.cities.any(City.city_name == self.selected_city)
-        )
-        print(req)  # THIS IS WORK FILTERS
-
-        # loader.filters = ['TEST',]
-
-        data = [loader.format(m) for m in loader.get_list(query, offset, limit)]
+        lawyer_list_output = [
+            lawyer
+            for lawyer in sql_query
+            if select_city in [str(city) for city in lawyer.cities]
+        ]
+        data = [loader.format(lawyer) for lawyer in lawyer_list_output]
         return Response(json.dumps(data), mimetype="application/json")
 
     column_labels = {
@@ -145,10 +130,13 @@ class ScheduleModelView(AdminModelView):
     }
 
     column_list = [
-        "lawyer_id",  # TODO develop - delete it
         "lawyers",
         "date",
         "time",
+    ]
+
+    column_sortable_list = [
+        "lawyers.name",
     ]
 
     column_searchable_list = [
@@ -190,7 +178,7 @@ class ScheduleModelView(AdminModelView):
         "lawyers": {
             "label": "Адвокат",
             "validators": [
-                DataRequired(message="Це поле обов'язкове поле."),
+                DataRequired(message="Це поле обов'язкове."),
                 MaxItemsValidator(max_items=1),
             ],
         },
@@ -203,3 +191,6 @@ class ScheduleModelView(AdminModelView):
         if form.data["lawyers"]:
             for lawyer in form.data["lawyers"]:
                 model.lawyer_id = lawyer.id  # save to db
+        if form.data["time"]:
+            res = _validate_time_format(form.data["time"])
+            model.time = res

--- a/calendarapi/admin/specialization.py
+++ b/calendarapi/admin/specialization.py
@@ -1,11 +1,16 @@
+from wtforms.validators import DataRequired
+
 from calendarapi.admin.common import AdminModelView
 
 
 class SpecializationAdminModelView(AdminModelView):
-    column_labels = {
-        "specialization_name": "Спеціалізація",
-    }
-
     column_list = ["specialization_name"]
+    column_labels = {"specialization_name": "Спеціалізація"}
 
     form_excluded_columns = ["lawyers"]
+
+    form_args = {
+        "specialization_name": {
+            "validators": [DataRequired(message="Це поле обов'язкове.")],
+        }
+    }

--- a/calendarapi/admin/user.py
+++ b/calendarapi/admin/user.py
@@ -6,7 +6,9 @@ from calendarapi.admin.common import AdminModelView
 
 class UserAdminModelView(AdminModelView):
     form_extra_fields = {
-        "password": StringField("password", validators=[DataRequired()])
+        "password": StringField(
+            "password", validators=[DataRequired(message="Це поле обов'язкове.")]
+        )
     }
     form_columns = ["username", "email", "is_active", "password", "description"]
     column_list = ["username", "email", "is_active", "description"]

--- a/calendarapi/api/schemas/lawyer.py
+++ b/calendarapi/api/schemas/lawyer.py
@@ -4,7 +4,12 @@ from calendarapi.extensions import fm, db, ma
 
 class LawyerSchema(fm.SQLAlchemyAutoSchema):
     city_id = ma.fields.Int(validate=ma.fields.validate.Range(min=1, max=3))
-    lawyer_mail = ma.fields.String(required=True, validate=ma.fields.validate.Email())
+    lawyer_mail = ma.fields.String(
+        required=True,
+        validate=[
+            ma.fields.validate.Email(error="Невірний формат пошти."),
+        ],
+    )
     name = ma.fields.String(
         required=True, validate=ma.fields.validate.Length(min=2, max=30)
     )

--- a/calendarapi/app.py
+++ b/calendarapi/app.py
@@ -3,6 +3,7 @@ from flask_sqlalchemy import record_queries
 from flask_admin import Admin
 from flask_babel import Babel
 from flask_mail import Mail
+
 from calendarapi import api, auth, manage
 from calendarapi.extensions import apispec, db, jwt, migrate, celery
 from calendarapi.auth.views import (
@@ -17,10 +18,9 @@ from calendarapi.admin import (
     CityAdminModelView,
     configure_login,
     LawyerAdminModelView,
-    SheduleModelView,
+    ScheduleModelView,
     SpecializationAdminModelView,
 )
-
 from calendarapi.models import (
     User,
     City,
@@ -37,7 +37,6 @@ from calendarapi.api.schemas import (
     AppointmentSchema,
     ScheduleSchema,
 )
-
 from calendarapi.api.resources import (
     UserList,
     UserResource,
@@ -74,9 +73,7 @@ def create_app(testing=False):
         apispec.spec.components.schema("CitySchema", schema=CitySchema)
         apispec.spec.components.schema("LawyerSchema", schema=LawyerSchema)
         apispec.spec.components.schema("ScheduleSchema", schema=ScheduleSchema)
-        apispec.spec.components.schema(
-            "SpecializationSchema", schema=SpecializationSchema
-        )
+        apispec.spec.components.schema("SpecializationSchema", schema=SpecializationSchema)
         apispec.spec.components.schema("AppointmentSchema", schema=AppointmentSchema)
         apispec.spec.path(view=ScheduleResource, app=app)
         apispec.spec.path(view=AppointmentResource, app=app)
@@ -100,15 +97,11 @@ def register_adminsite(app):
         base_template="master.html",
         template_mode="bootstrap4",
     )
-    admin.add_view(
-        UserAdminModelView(User, db.session, name="Користувачі", category="Керування")
-    )
+    admin.add_view(UserAdminModelView(User, db.session, name="Користувачі", category="Керування"))
     admin.add_view(CityAdminModelView(City, db.session, name="Місто"))
-    admin.add_view(
-        SpecializationAdminModelView(Specialization, db.session, name="Cпеціалізація")
-    )
+    admin.add_view(SpecializationAdminModelView(Specialization, db.session, name="Cпеціалізація"))
     admin.add_view(LawyerAdminModelView(Lawyer, db.session, name="Адвокати"))
-    admin.add_view(SheduleModelView(Schedule, db.session, name="Розклад"))
+    admin.add_view(ScheduleModelView(Schedule, db.session, name="Розклад"))
 
 
 def configure_extensions(app):
@@ -127,9 +120,7 @@ def configure_cli(app):
 def configure_apispec(app):
     """Configure APISpec for swagger support"""
     apispec.init_app(app, security=[{"jwt": []}])
-    apispec.spec.components.security_scheme(
-        "jwt", {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
-    )
+    apispec.spec.components.security_scheme("jwt", {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"})
     apispec.spec.components.schema(
         "PaginatedResult",
         {
@@ -170,11 +161,7 @@ def sql_debug(response):
     for query in queries:
         total_duration += query.duration
     print("=" * 80)
-    print(
-        " SQL Queries - {0} Queries Executed in {1}ms".format(
-            len(queries), round(total_duration * 1000, 2)
-        )
-    )
+    print(" SQL Queries - {0} Queries Executed in {1}ms".format(len(queries), round(total_duration * 1000, 2)))
     return response
 
 

--- a/calendarapi/app.py
+++ b/calendarapi/app.py
@@ -73,7 +73,9 @@ def create_app(testing=False):
         apispec.spec.components.schema("CitySchema", schema=CitySchema)
         apispec.spec.components.schema("LawyerSchema", schema=LawyerSchema)
         apispec.spec.components.schema("ScheduleSchema", schema=ScheduleSchema)
-        apispec.spec.components.schema("SpecializationSchema", schema=SpecializationSchema)
+        apispec.spec.components.schema(
+            "SpecializationSchema", schema=SpecializationSchema
+        )
         apispec.spec.components.schema("AppointmentSchema", schema=AppointmentSchema)
         apispec.spec.path(view=ScheduleResource, app=app)
         apispec.spec.path(view=AppointmentResource, app=app)
@@ -97,9 +99,13 @@ def register_adminsite(app):
         base_template="master.html",
         template_mode="bootstrap4",
     )
-    admin.add_view(UserAdminModelView(User, db.session, name="Користувачі", category="Керування"))
+    admin.add_view(
+        UserAdminModelView(User, db.session, name="Користувачі", category="Керування")
+    )
     admin.add_view(CityAdminModelView(City, db.session, name="Місто"))
-    admin.add_view(SpecializationAdminModelView(Specialization, db.session, name="Cпеціалізація"))
+    admin.add_view(
+        SpecializationAdminModelView(Specialization, db.session, name="Cпеціалізація")
+    )
     admin.add_view(LawyerAdminModelView(Lawyer, db.session, name="Адвокати"))
     admin.add_view(ScheduleModelView(Schedule, db.session, name="Розклад"))
 
@@ -120,7 +126,9 @@ def configure_cli(app):
 def configure_apispec(app):
     """Configure APISpec for swagger support"""
     apispec.init_app(app, security=[{"jwt": []}])
-    apispec.spec.components.security_scheme("jwt", {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"})
+    apispec.spec.components.security_scheme(
+        "jwt", {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
+    )
     apispec.spec.components.schema(
         "PaginatedResult",
         {
@@ -161,7 +169,11 @@ def sql_debug(response):
     for query in queries:
         total_duration += query.duration
     print("=" * 80)
-    print(" SQL Queries - {0} Queries Executed in {1}ms".format(len(queries), round(total_duration * 1000, 2)))
+    print(
+        " SQL Queries - {0} Queries Executed in {1}ms".format(
+            len(queries), round(total_duration * 1000, 2)
+        )
+    )
     return response
 
 

--- a/calendarapi/models/schedule.py
+++ b/calendarapi/models/schedule.py
@@ -7,7 +7,7 @@ class Schedule(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     lawyer_id = db.Column(
         db.Integer,
-        db.ForeignKey("lawyers.id"),
+        db.ForeignKey("lawyers.id", ondelete="CASCADE"),
     )
     date = db.Column(db.Date, nullable=False)
     time = db.Column(db.ARRAY(db.Time))

--- a/calendarapi/models/specialization.py
+++ b/calendarapi/models/specialization.py
@@ -5,7 +5,7 @@ class Specialization(db.Model):
     __tablename__ = "specializations"
 
     id = db.Column(db.Integer, primary_key=True)
-    specialization_name = db.Column(db.String(255), unique=True)
+    specialization_name = db.Column(db.String(255), nullable=False, unique=True)
 
     def __repr__(self):
         return f"{self.specialization_name}"

--- a/calendarapi/static/styles/green_mist.css
+++ b/calendarapi/static/styles/green_mist.css
@@ -248,6 +248,10 @@
     color: var(--text-color);
   }
   /* navigations */
+  .select2-results .select2-highlighted{
+    background: #616161 !important;
+    color: #fff;
+}
   .breadcrumb {
     background-color: var(--button);
   }
@@ -303,6 +307,11 @@
     color: var(--text-color);
     background-color: var(--table-header-background);
     border-color: var(--header-background);
+  }
+  fieldset {
+    background: rgb(193, 193, 193);
+    border-color: var(--table-border);
+    border-radius: 5px;
   }
   .page-link {
     color: var(--header-background);

--- a/calendarapi/templates/admin/custom_list.html
+++ b/calendarapi/templates/admin/custom_list.html
@@ -1,0 +1,65 @@
+{% extends 'admin/model/list.html' %}
+{{ super() }}
+{% block model_menu_bar %}
+
+<ul class="nav nav-tabs">
+    <li class="nav-item">
+        <a href="javascript:void(0)" class="nav-link active">{{ _gettext('List') }}{% if count %} ({{ count }}){% endif
+            %}</a>
+    </li>
+
+    {% if admin_view.can_create %}
+    <li class="nav-item">
+        {%- if admin_view.create_modal -%}
+        {{ lib.add_modal_button(url=get_url('.create_view', url=return_url, modal=True), btn_class='nav-link',
+        title=_gettext('Create New Record'), content=_gettext('Create')) }}
+        {% else %}
+        <a href="{{ get_url('.create_view', url=return_url) }}" title="{{ _gettext('Create New Record') }}"
+            class="nav-link">{{ _gettext('Create') }}</a>
+        {%- endif -%}
+    </li>
+    {% endif %}
+
+    {% if admin_view.can_export %}
+    {{ model_layout.export_options() }}
+    {% endif %}
+
+    {% block model_menu_bar_before_filters %}{% endblock %}
+
+    {% if filters %}
+    <li class="nav-item dropdown">
+        {{ model_layout.filter_options() }}
+    </li>
+    {% endif %}
+
+    {% if can_set_page_size %}
+    <li class="nav-item dropdown">
+        {{ model_layout.page_size_form(page_size_url) }}
+    </li>
+    {% endif %}
+
+    {% if actions %}
+    <li class="nav-item dropdown">
+        {{ actionlib.dropdown(actions) }}
+    </li>
+    {% endif %}
+
+    {% if search_supported %}
+    <li class="nav-item ml-2">
+        {{ model_layout.search_form() }}
+    </li>
+    {% endif %}
+    {% block model_menu_bar_after_filters %}{% endblock %}
+    <form action="" method="post" class="nav-item dropdown ml-auto">
+        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true"
+            aria-expanded="false">
+            {{admin_view.current_city}}
+        </a>
+        <div class="dropdown-menu">
+            <input class="dropdown-item" type="submit" name="city" value="Усі міста" />
+            {% for city in admin_view.get_item() %}
+            <input class="dropdown-item" type="submit" name="city" value="{{city.city_name}}" />
+            {% endfor %}
+        </div>
+    </form>
+    {% endblock %}

--- a/calendarapi/templates/admin/custom_list.html
+++ b/calendarapi/templates/admin/custom_list.html
@@ -52,14 +52,14 @@
     {% block model_menu_bar_after_filters %}{% endblock %}
     <form action="" method="post" class="nav-item dropdown ml-auto">
         <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true"
-            aria-expanded="false">
-            {{admin_view.current_city}}
-        </a>
-        <div class="dropdown-menu">
-            <input class="dropdown-item" type="submit" name="city" value="Усі міста" />
-            {% for city in admin_view.get_item() %}
-            <input class="dropdown-item" type="submit" name="city" value="{{city.city_name}}" />
-            {% endfor %}
-        </div>
-    </form>
+        aria-expanded="false">
+        {{admin_view.current_city}}
+    </a>
+    <div class="dropdown-menu">
+        <input class="dropdown-item" type="submit" name="city" value="Усі міста" />
+        {% for city in admin_view.get_item() %}
+        <input class="dropdown-item" type="submit" name="city" value="{{city.city_name}}" />
+        {% endfor %}
+    </div>
+</form>
     {% endblock %}

--- a/calendarapi/templates/admin/index.html
+++ b/calendarapi/templates/admin/index.html
@@ -10,7 +10,7 @@
         background-size: 100%;
         /* background-position: 0% 12%; */
         background-position: center;
-        background-repeat: no-repeat;
+        background-repeat: repeat;
       }
       .bg-dark {
         border: solid 1px rgb(89, 65, 6);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Flask_Admin from local distribution ¯\_(ツ)_/¯
+./custom_dist/Flask_Admin-1.6.1-py3-none-any.whl
 marshmallow==3.20.1
 flask==2.3.1
 flask-restful==0.3.10
@@ -5,9 +7,9 @@ flask-migrate==4.0.5
 flask-sqlalchemy==3.1.1
 flask-marshmallow==0.15.0
 flask-jwt-extended==4.5.3
-flask-admin==1.6.1
 flask_login==0.6.2
 Flask-Babel==4.0.0
+Flask-Mail==0.9.1
 Werkzeug==2.3.7
 marshmallow-sqlalchemy==0.29.0
 python-dotenv==1.0.0
@@ -22,4 +24,3 @@ flower==2.0.1
 Flask-Caching==2.1.0
 black
 factory_boy
-Flask-Mail

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -56,5 +56,4 @@ class ScheduleFactory(factory.Factory):
     class Meta:
         model = Schedule
 
-    lawyer_id = factory.Faker("random_int", min=1, max=100)
     date = factory.Faker("date_between", start_date="today", end_date="+30d")


### PR DESCRIPTION
- add search strings in the sections (lawyers, schedule) to search for lawyers by many criteria;
- implemented a filter by city, all data is displayed in the Schedules section using a drop-down menu with a list of cities; 
- Rebuilt the Flask Admin package and archived it locally for easy customization (added localization to validation warnings, changed the separator in the Times field of the Schedules section when adding new shedule hours from a comma to a space; 
- Implemented deletion of relationship data in other tables when deleting a record from the Lawyers section; 
- changed the name field in the Specializations section to required.